### PR TITLE
remove toLowerCase()

### DIFF
--- a/generators/entity-client/templates/react/src/main/webapp/app/entities/entity-update.tsx.ejs
+++ b/generators/entity-client/templates/react/src/main/webapp/app/entities/entity-update.tsx.ejs
@@ -614,7 +614,7 @@ _%>
                 onChange={this.<%= relationshipFieldName %>Update}>
                 <option value="" key="0" />
                 {
-                  (<%= otherEntityNamePlural %>) ? <%=otherEntityNamePlural.toLowerCase() %>.map(otherEntity =>
+                  (<%= otherEntityNamePlural %>) ? <%=otherEntityNamePlural %>.map(otherEntity =>
                   <option
                       value={otherEntity.<%=otherEntityField%>}
                       key={otherEntity.id}>


### PR DESCRIPTION
This will fail whenever the entity name contains uppercase chars after the first char.
